### PR TITLE
Run local EAS build on GitHub Actions

### DIFF
--- a/.github/workflows/e2e-local-build-on-pr
+++ b/.github/workflows/e2e-local-build-on-pr
@@ -1,0 +1,49 @@
+name: Run E2E tests with Detox
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  run-tests:
+    runs-on: macos-latest
+
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v2
+
+      - name: 🏗 Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: yarn
+          
+      - name: 🏗 Setup Expo and EAS
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build app locally using EAS
+        run: |
+          eas build --local \
+            --non-interactive \
+            --output=./bin/easdetoxci.app \
+            --platform=ios \
+            --profile=development-sim
+
+      - name: Setup Detox
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+
+      - name: 📦 Install dependencies
+        run: yarn install
+
+      - name: Open Simulator & run tests
+        run: |
+          open -a Simulator.app
+          sleep 10
+          xcrun simctl install booted ./bin/easdetoxci.app
+          sleep 15
+          yarn detox test --configuration ios

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,9 @@
-name: Run E2E tests with detox
+name: Run E2E tests with Detox
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-    inputs:
-      downloadUrl:
-        description: 'Link to expo build url'
-        required: true
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run-tests:
@@ -22,20 +19,13 @@ jobs:
           node-version: 12.x
           cache: yarn
 
-      - name: Download build
-        uses: suisei-cn/actions-download-file@v1
-        id: downloadedApp
-        with:
-          url: ${{ github.event.inputs.downloadUrl }}
-          target: bin/
-
-      - name: Untar app build
+      - name: Build app locally using EAS
         run: |
-          cd bin
-          ls -a
-          for f in *.tar.gz; do tar -xvf "$f"; done
-          ls
-          cd ..
+          eas build --local \
+            --non-interactive \
+            --output=./bin/easdetoxci.app \
+            --platform=ios \
+            --profile=development-sim
 
       - name: Setup detox
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,12 @@
-name: Run E2E tests with Detox
+name: Run E2E tests with detox
 
 on:
-  pull_request:
-    branches:
-      - master
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      downloadUrl:
+        description: 'Link to expo build url'
+        required: true
 
 jobs:
   run-tests:
@@ -18,21 +21,21 @@ jobs:
         with:
           node-version: 12.x
           cache: yarn
-          
-      - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Build app locally using EAS
+      - name: Download build
+        uses: suisei-cn/actions-download-file@v1
+        id: downloadedApp
+        with:
+          url: ${{ github.event.inputs.downloadUrl }}
+          target: bin/
+
+      - name: Untar app build
         run: |
-          eas build --local \
-            --non-interactive \
-            --output=./bin/easdetoxci.app \
-            --platform=ios \
-            --profile=development-sim
+          cd bin
+          ls -a
+          for f in *.tar.gz; do tar -xvf "$f"; done
+          ls
+          cd ..
 
       - name: Setup detox
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           node-version: 12.x
           cache: yarn
+          
+      - name: 🏗 Setup Expo and EAS
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Build app locally using EAS
         run: |


### PR DESCRIPTION
Hi there, thanks for this example!

I just wanted to open this PR after having looked at @byCedric's [`eas-gh` example](https://github.com/karlhorky/eas-gha/blob/main/.github/workflows/build.yml).

This uses the new experimental local EAS builds, enabling fully local builds.

Caveat: this does make the build take longer.

If you would like to preserve the existing workflow, I could imagine this being added as a second example workflow.