### PR TITLE
Remove unnecessary steps

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,11 @@
-name: Run E2E tests with detox
+name: Run E2E tests with Detox
 
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       downloadUrl:
-        description: 'Link to expo build url'
+        description: 'Link to Expo build url'
         required: true
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
 
-      - name: 🏗 Setup Node
+      - name: 🏗 Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 12.x
@@ -37,7 +37,7 @@ jobs:
           ls
           cd ..
 
-      - name: Setup detox
+      - name: Setup Detox
         run: |
           brew tap wix/brew
           brew install applesimutils
@@ -45,10 +45,5 @@ jobs:
       - name: 📦 Install dependencies
         run: yarn install
 
-      - name: Open simulator & run tests
-        run: |
-          open -a Simulator.app
-          sleep 10
-          xcrun simctl install booted ./bin/easdetoxci.app
-          sleep 15
-          yarn detox test --configuration ios
+      - name: Open Simulator & run tests
+        run: yarn detox test --configuration ios


### PR DESCRIPTION
As far as I can tell from my testing, starting the Simulator and installing the app is done by the `detox test` command itself