### PR TITLE
Run local EAS build on GitHub Actions

### DIFF
--- a/.github/workflows/e2e-local-build-on-pr.yml
+++ b/.github/workflows/e2e-local-build-on-pr.yml
@@ -41,9 +41,4 @@ jobs:
         run: yarn install
 
       - name: Open Simulator & run tests
-        run: |
-          open -a Simulator.app
-          sleep 10
-          xcrun simctl install booted ./bin/easdetoxci.app
-          sleep 15
-          yarn detox test --configuration ios
+        run: yarn detox test --configuration ios

--- a/.github/workflows/e2e-local-build-on-pr.yml
+++ b/.github/workflows/e2e-local-build-on-pr.yml
@@ -1,0 +1,49 @@
+name: Run E2E tests with Detox
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  run-tests:
+    runs-on: macos-latest
+
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v2
+
+      - name: 🏗 Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: yarn
+
+      - name: 🏗 Setup Expo and EAS
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build app locally using EAS
+        run: |
+          eas build --local \
+            --non-interactive \
+            --output=./bin/easdetoxci.app \
+            --platform=ios \
+            --profile=development-sim
+
+      - name: Setup Detox
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+
+      - name: 📦 Install dependencies
+        run: yarn install
+
+      - name: Open Simulator & run tests
+        run: |
+          open -a Simulator.app
+          sleep 10
+          xcrun simctl install booted ./bin/easdetoxci.app
+          sleep 15
+          yarn detox test --configuration ios

--- a/.github/workflows/e2e-local-build-on-pr.yml
+++ b/.github/workflows/e2e-local-build-on-pr.yml
@@ -30,7 +30,9 @@ jobs:
             --non-interactive \
             --output=./bin/easdetoxci.app \
             --platform=ios \
-            --profile=development-sim
+            --profile=development-sim \
+            --clear-cache \
+            --json
 
       - name: Setup Detox
         run: |


### PR DESCRIPTION
Supersedes #2

Hi there, thanks for this example!

I just wanted to open this PR after having looked at @byCedric's [`eas-gh` example](https://github.com/karlhorky/eas-gha/blob/main/.github/workflows/build.yml).

This uses the new experimental local EAS builds, enabling fully local builds.

Caveat: this does make the build take longer.

If you would like to preserve the existing workflow, I could imagine this being added as a second example workflow.